### PR TITLE
Enhance: Display Location below the name line

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,9 +6,10 @@ export const Hero = () => {
     <section className="mb-16">
       <div className="flex items-center gap-8 mb-8">
         <div className="flex-1">
-          <h1 className="text-5xl font-bold mb-4 text-white">Hi, Ansh here</h1>
+          <h1 className="text-5xl font-bold mb-1 text-white">Hi, Ansh here</h1>
+          <p className='mb-4'>📍Rajasthan, India</p>
           <p className="text-xl text-gray-400">
-            Building open-source dev tools & automations 📍Rajasthan, India
+            Building open-source dev tools & automations
           </p>
         </div>
         <Avatar className="w-24 h-24">


### PR DESCRIPTION
Fixes: #51

Display Location below the name line

<img width="551" height="156" alt="scrnli_93UU2KhrYs3ry2" src="https://github.com/user-attachments/assets/f21c1352-96c1-4d59-8d22-a1fe752abfb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Hero section for a cleaner, more compact layout.
  * Reduced spacing below the main title for tighter visual hierarchy.
  * Added a dedicated location line: “📍Rajasthan, India” beneath the title.
  * Refined tagline to “Building open-source dev tools & automations” for clearer messaging (removed location from paragraph).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->