### PR TITLE
fix: adjust mobile navbar button positioning (Bounty #63)

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -141,7 +141,7 @@ export const Navigation = () => {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          'md:hidden fixed top-4 right-4 mt-6 z-50',
+          'md:hidden fixed top-4 right-4 z-50',
           'w-12 h-12 flex items-center justify-center',
           'bg-gray-900/80 backdrop-blur-md rounded-xl border border-gray-700',
           'text-gray-300 hover:text-white hover:bg-gray-800/90',


### PR DESCRIPTION
Removed redundant mt-6 margin that was pushing the mobile
menu button too far down on mobile viewports.

Bounty: #63 - Fix navbar in Mobile view (₹100)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted mobile menu toggle button positioning by removing excess vertical spacing for improved visual alignment on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->